### PR TITLE
Remove the 3des cipher used by the kube-rbac-proxy by default

### DIFF
--- a/stable/grc/templates/grc-policy-propagator-deployment.yaml
+++ b/stable/grc/templates/grc-policy-propagator-deployment.yaml
@@ -90,6 +90,7 @@ spec:
         - --v=6
         - "--tls-cert-file=/var/run/policy-metrics-cert/tls.crt"
         - "--tls-private-key-file=/var/run/policy-metrics-cert/tls.key"
+        - "--tls-min-version=VersionTLS13"
         ports:
         - containerPort: 8443
           name: https


### PR DESCRIPTION
The metrics service endpoint is an httpd connection using the default
go ciphers which includes `TLS_RSA_WITH_3DES_EDE_CBC_SHA`.  This cipher
is graded as a `C` due to sweet32.  Even though the only use of this
connection is for internal metric gathering, we want to move up to
TLS 1.3 which doesn't have that cipher.

Refs:
 - https://github.com/stolostron/backlog/issues/14361

Signed-off-by: Gus Parvin <gparvin@redhat.com>