### PR TITLE
Update permissions and remove simulation mode

### DIFF
--- a/stable/grc/templates/grc-policy-addon-clusterrole.yaml
+++ b/stable/grc/templates/grc-policy-addon-clusterrole.yaml
@@ -26,6 +26,17 @@ rules:
   - watch
 - apiGroups:
   - addon.open-cluster-management.io
+  resourceNames:
+  - cert-policy-controller
+  - config-policy-controller
+  - governance-policy-framework
+  - iam-policy-controller
+  resources:
+  - clustermanagementaddons/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - addon.open-cluster-management.io
   resources:
   - managedclusteraddons
   verbs:
@@ -34,6 +45,17 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+  - addon.open-cluster-management.io
+  resourceNames:
+  - cert-policy-controller
+  - config-policy-controller
+  - governance-policy-framework
+  - iam-policy-controller
+  resources:
+  - managedclusteraddons
+  verbs:
+  - delete
 - apiGroups:
   - addon.open-cluster-management.io
   resourceNames:

--- a/stable/grc/templates/grc-policy-addon-deployment.yaml
+++ b/stable/grc/templates/grc-policy-addon-deployment.yaml
@@ -87,8 +87,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: SIMULATION_MODE
-          value: "on"
         - name: CERT_POLICY_CONTROLLER_IMAGE
           value: {{ .Values.global.imageOverrides.cert_policy_controller }}
         - name: IAM_POLICY_CONTROLLER_IMAGE


### PR DESCRIPTION
Updates permissions to match https://github.com/stolostron/governance-policy-addon-controller/pull/6 and make setting the ownerRef work, and removes the simulation mode.

This PR should be synchronized with https://github.com/stolostron/klusterlet-addon-controller/pull/96 so that exactly one controller is managing the addons.