### PR TITLE
Add permissions for the encryption secret

### DIFF
--- a/stable/grc/templates/grc-policy-addon-clusterrole.yaml
+++ b/stable/grc/templates/grc-policy-addon-clusterrole.yaml
@@ -123,7 +123,7 @@ rules:
   - cert-policy-controller
   - config-policy-controller
   - iam-policy-controller
-  - policy-framework
+  - governance-policy-framework
   resources:
   - leases
   verbs:
@@ -131,6 +131,16 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - policy-encryption-key
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - policy.open-cluster-management.io


### PR DESCRIPTION
The policy addon controller doesn't use this directly, but needs the
permission in order to create the role that the framework addon will
use on the hub.

Refs:
 - https://github.com/stolostron/backlog/issues/20228
 - https://github.com/stolostron/governance-policy-addon-controller/pull/10

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>